### PR TITLE
ci: Add the initial skeleton to lint PRs for github issues

### DIFF
--- a/.github/workflows/check-linked-issues.md
+++ b/.github/workflows/check-linked-issues.md
@@ -1,0 +1,33 @@
+name: Check Linked Issues
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+    branches:
+      - master
+
+permissions:
+  issues: read
+  pull-requests: write
+
+jobs:
+  check-linked-issues:
+    name: Verify PR has linked issue
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+      - name: Check for linked issues
+        if: steps.should_skip.outputs.skip != 'true'
+        uses: nearform-actions/github-action-check-linked-issues@v1
+        # TODO: Remove this once action is validated
+        continue-on-error: true
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          comment: false
+          loose-matching: true
+          exclude-labels: skip-issue-check


### PR DESCRIPTION
**What changed?**

Initializes the skeleton for a GitHub action that validates whether an issue has been linked in the PR description. 

**Why?**

* Make it easier to create release notes by ensuring PRs are linked to their relevant features 
* Increase the context available to a reviewer (and decrease the overhead of duplicating feature information when creating PR descriptions) 

**How did you test it?**

Unfortunately GitHub actions can't be tested until they've hit main. This PR adds a skeleton that will allow testing the GitHub action within my fork. 

**Potential risks**

It could block CI. If so will revert. 


---

## Reviewer Validation

**PR Description Quality** (check these before reviewing code):

- [ ] **"What changed"** provides a clear 1-2 line summary
  - [ ] Project Issue is linked
- [ ] **"Why"** explains the full motivation with sufficient context
- [ ] **Testing is documented:**
  - [ ] Unit test commands are included (with exact `go test` invocation)
  - [ ] Integration test setup/commands included (if integration tests were run)
  - [ ] Canary testing details included (if canary was mentioned)
- [ ] **Potential risks** section is thoughtfully filled out (or legitimately N/A)
- [ ] **Release notes** included if this completes a user-facing feature
- [ ] **Documentation** needs are addressed (or noted if uncertain)
